### PR TITLE
Allow --preferred-anat-modality value of none

### DIFF
--- a/python_code/run.py
+++ b/python_code/run.py
@@ -426,10 +426,9 @@ def main():
 
             
             print('Preferred anatomical modality is: ' + args.preferred_anat_modality)
-            if args.preferred_anat_modality != 'none':
-                if (len(t1w_anats) + len(t2w_anats)) == 0:
-                    print('No T1w or T2w image found for ' + session_path + ', skipping processing for current session.\n')
-                    continue
+            if (args.preferred_anat_modality != 'none') and ((len(t1w_anats) + len(t2w_anats)) == 0):
+                print('No T1w or T2w image found for ' + session_path + ', skipping processing for current session.\n')
+                continue
 
             #If no anat is going to be used
             elif args.preferred_anat_modality == 'none':


### PR DESCRIPTION
Adds 'none' as an allowed option for --preferred-anat-modality. In this case, a T1w/T2w image will neither be utilized or looked for. This processing without anat is useful for doing QC of the MRS spectra.